### PR TITLE
Fix content extraction bug for IDML XML

### DIFF
--- a/translator/text_extractor.py
+++ b/translator/text_extractor.py
@@ -13,7 +13,10 @@ def extract_content_elements(tree):
     Najde všechny <Content> elementy s textem k překladu
     Vrací seznam (element, původní text)
     """
-    content_elements = tree.xpath('//Content')
+    # IDML soubory používají výchozí XML jmenné prostory, takže běžný XPath
+    # '//Content' by nenašel žádné elementy. Hledáme proto podle jména
+    # elementu bez ohledu na namespace.
+    content_elements = tree.xpath('//*[local-name()="Content"]')
     result = []
     for el in content_elements:
         if el.text and el.text.strip():  # ignoruj prázdné


### PR DESCRIPTION
### **User description**
## Summary
- handle default XML namespaces when searching `<Content>` nodes

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pylint --errors-only $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68640852e55c8332b9bd3fe8aed2fbee


___

### **PR Type**
Bug fix


___

### **Description**
- Fix XML namespace handling for IDML content extraction

- Replace simple XPath with namespace-agnostic selector

- Ensure `<Content>` elements are found regardless of namespaces


___

### **Changes diagram**

```mermaid
flowchart LR
  A["XPath '//Content'"] -- "fails with namespaces" --> B["No elements found"]
  C["XPath '//*[local-name()=\"Content\"]'"] -- "namespace-agnostic" --> D["Content elements extracted"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>text_extractor.py</strong><dd><code>Fix namespace-aware Content element extraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

translator/text_extractor.py

<li>Replace simple XPath selector with namespace-agnostic version<br> <li> Add explanatory comment about IDML namespace handling<br> <li> Use <code>local-name()</code> function to match elements regardless of namespace


</details>


  </td>
  <td><a href="https://github.com/Flamendrin/idml-translator/pull/1/files#diff-a420a7182060a14e384079c411c39b43ce092aaf32d8cb3e0203e45201f4f657">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>