### PR TITLE
Fix setup script instruction in Czech

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -12,4 +12,4 @@ echo "📦 Instaluji Python balíčky..."
 pip install --upgrade pip
 pip install flask lxml openai python-dotenv
 
-echo "✅ Hotovo. Spusť ./start.sh pro spuštění aplikace."
+echo "✅ Hotovo. Spusťte ./start.sh pro spuštění aplikace."


### PR DESCRIPTION
## Summary
- correct the instruction line in `setup.sh`

## Testing
- `git log -1 -p`


------
https://chatgpt.com/codex/tasks/task_e_68640998d2688332a781d9d7cd51dc6a