### PR TITLE
Implement prompt UI and cleanup service

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -55,15 +55,13 @@
       border-radius: 10px;
       box-shadow: 0 2px 8px rgba(0,0,0,0.1);
     }
-    .spinner {
-      text-align: center;
+    .progress-wrapper {
       margin-top: 30px;
+      text-align: center;
     }
-    .spinner:after {
-      content: "⏳ Překlad probíhá, vyčkejte...";
-      display: block;
-      margin-top: 10px;
-      font-style: italic;
+    progress {
+      width: 100%;
+      height: 20px;
     }
     .footer {
       text-align: center;
@@ -95,8 +93,8 @@
     }
   </style>
   <script>
-    function showSpinner() {
-      document.getElementById('spinner').style.display = 'block';
+    function showProgress() {
+      document.getElementById('progressWrapper').style.display = 'block';
     }
   </script>
 </head>
@@ -110,7 +108,7 @@
   <div class="error">{{ error }}</div>
   {% endif %}
 
-  <form method="POST" enctype="multipart/form-data" onsubmit="showSpinner()">
+  <form method="POST" enctype="multipart/form-data" onsubmit="showProgress()">
     <label for="idml_file">Vyber IDML soubor:</label>
     <input type="file" name="idml_file" accept=".idml" required>
 
@@ -133,10 +131,16 @@
       <label><input type="checkbox" name="languages" value="hu"> Maďarština</label>
     </div>
 
+    <label for="prompt">AI Prompt:</label>
+    <textarea name="prompt" rows="4">{{ prompt_text }}</textarea>
+
     <button type="submit">Nahrát a přeložit</button>
   </form>
 
-  <div id="spinner" class="spinner" style="display: none;"></div>
+  <div id="progressWrapper" class="progress-wrapper" style="display: none;">
+    <progress></progress>
+    <p>⏳ Překlad probíhá, vyčkejte...</p>
+  </div>
 
   {% if links %}
   <div class="results">

--- a/translator/openai_client.py
+++ b/translator/openai_client.py
@@ -7,6 +7,12 @@ import time
 from openai import OpenAI
 from openai.types.chat import ChatCompletionMessageParam
 
+DEFAULT_PROMPT = (
+    "You are a professional translator. "
+    "Translate the following XML-safe text from {from_lang} to {to_lang}. "
+    "Do not change XML tags."
+)
+
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 LANGUAGE_MAP = {
@@ -18,19 +24,20 @@ LANGUAGE_MAP = {
     'hu': 'Hungarian',
 }
 
-def translate_text(text: str, source_lang: str, target_lang: str) -> str:
+def translate_text(
+    text: str,
+    source_lang: str,
+    target_lang: str,
+    system_prompt: str | None = None,
+) -> str:
     """Translate ``text`` from ``source_lang`` to ``target_lang`` using ChatGPT."""
     from_lang = LANGUAGE_MAP.get(source_lang, source_lang)
     to_lang = LANGUAGE_MAP.get(target_lang, target_lang)
+    prompt = (system_prompt or DEFAULT_PROMPT).format(
+        from_lang=from_lang, to_lang=to_lang
+    )
     messages: list[ChatCompletionMessageParam] = [
-        {
-            "role": "system",
-            "content": (
-                "You are a professional translator. "
-                "Translate the following XML-safe text from "
-                f"{from_lang} to {to_lang}. Do not change XML tags."
-            ),
-        },
+        {"role": "system", "content": prompt},
         {"role": "user", "content": text},
     ]
     try:
@@ -44,13 +51,19 @@ def translate_text(text: str, source_lang: str, target_lang: str) -> str:
         print(f"❌ Chyba při překladu: {e}")
         return text
 
-def batch_translate(texts: list[str], target_langs: list[str], source_lang: str) -> dict[str, list[str]]:
+def batch_translate(
+    texts: list[str],
+    target_langs: list[str],
+    source_lang: str,
+    system_prompt: str | None = None,
+) -> dict[str, list[str]]:
     """Translate a list of texts into multiple languages sequentially."""
     results = {lang: [] for lang in target_langs}
     for text in texts:
         for lang in target_langs:
             print(f"Překládám z {source_lang} do {lang}: {text[:40]}...")
-            translation = translate_text(text, source_lang, lang)
+            translation = translate_text(text, source_lang, lang, system_prompt)
             results[lang].append(translation)
             time.sleep(1)
     return results
+


### PR DESCRIPTION
## Summary
- expose the AI system prompt in the web UI so it can be edited
- show a progress bar during translation
- add background cleanup for old uploaded/result files
- extend translator to accept a custom prompt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68641b14f7408332933ff10556b41621