### PR TITLE
Implement dynamic progress and language tag input

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -55,15 +55,13 @@
       border-radius: 10px;
       box-shadow: 0 2px 8px rgba(0,0,0,0.1);
     }
-    .spinner {
-      text-align: center;
+    .progress-wrapper {
       margin-top: 30px;
+      text-align: center;
     }
-    .spinner:after {
-      content: "⏳ Překlad probíhá, vyčkejte...";
-      display: block;
-      margin-top: 10px;
-      font-style: italic;
+    progress {
+      width: 100%;
+      height: 20px;
     }
     .footer {
       text-align: center;
@@ -93,11 +91,73 @@
       border-radius: 5px;
       border: 1px solid #f5c6cb;
     }
+    .tag-input {
+      border: 1px solid #ccc;
+      padding: 5px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px;
+    }
+    .tag-input input {
+      border: none;
+      flex: 1;
+      min-width: 80px;
+    }
+    .tag {
+      background: #007bff;
+      color: #fff;
+      border-radius: 3px;
+      padding: 2px 6px;
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+    }
+    .tag span { cursor: pointer; }
   </style>
   <script>
-    function showSpinner() {
-      document.getElementById('spinner').style.display = 'block';
-    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const container = document.getElementById('langTags');
+      const input = document.getElementById('langInput');
+      const hidden = document.getElementById('languagesHidden');
+      const tags = [];
+
+      function render() {
+        container.querySelectorAll('.tag').forEach(t => t.remove());
+        tags.forEach(code => {
+          const span = document.createElement('span');
+          span.className = 'tag';
+          span.textContent = code;
+          const x = document.createElement('span');
+          x.textContent = '×';
+          x.onclick = () => { remove(code); };
+          span.appendChild(x);
+          container.insertBefore(span, input);
+        });
+        hidden.value = tags.join(',');
+      }
+
+      function add(code) {
+        if (!code || tags.includes(code)) return;
+        tags.push(code);
+        render();
+      }
+
+      function remove(code) {
+        const i = tags.indexOf(code);
+        if (i >= 0) tags.splice(i, 1);
+        render();
+      }
+
+      input.addEventListener('keydown', e => {
+        if (e.key === 'Enter' || e.key === ',') {
+          e.preventDefault();
+          const val = input.value.replace(',', '').trim();
+          add(val);
+          input.value = '';
+        }
+      });
+    });
   </script>
 </head>
 <body>
@@ -110,33 +170,31 @@
   <div class="error">{{ error }}</div>
   {% endif %}
 
-  <form method="POST" enctype="multipart/form-data" onsubmit="showSpinner()">
+  <form method="POST" enctype="multipart/form-data">
     <label for="idml_file">Vyber IDML soubor:</label>
     <input type="file" name="idml_file" accept=".idml" required>
 
     <label for="source_lang">Zdrojový jazyk:</label>
-    <select name="source_lang" required>
-      <option value="cs">Čeština</option>
-      <option value="en">Angličtina</option>
-      <option value="de">Němčina</option>
-      <option value="sk">Slovenština</option>
-      <option value="pl">Polština</option>
-      <option value="hu">Maďarština</option>
-    </select>
+    <input type="text" name="source_lang" list="langCodes" required>
 
     <label for="languages">Cílové jazyky:</label>
-    <div class="checkbox-group">
-      <label><input type="checkbox" name="languages" value="en"> Angličtina</label>
-      <label><input type="checkbox" name="languages" value="de"> Němčina</label>
-      <label><input type="checkbox" name="languages" value="sk"> Slovenština</label>
-      <label><input type="checkbox" name="languages" value="pl"> Polština</label>
-      <label><input type="checkbox" name="languages" value="hu"> Maďarština</label>
+    <div id="langTags" class="tag-input">
+      <input id="langInput" type="text" list="langCodes" placeholder="zadejte kód a Enter">
     </div>
+    <input type="hidden" name="languages" id="languagesHidden">
+
+    <datalist id="langCodes">
+      {% for code, name in lang_names.items() %}
+      <option value="{{ code }}">{{ name }}</option>
+      {% endfor %}
+    </datalist>
+
+    <label for="prompt">AI Prompt:</label>
+    <textarea name="prompt" rows="4">{{ prompt_text }}</textarea>
 
     <button type="submit">Nahrát a přeložit</button>
   </form>
 
-  <div id="spinner" class="spinner" style="display: none;"></div>
 
   {% if links %}
   <div class="results">

--- a/templates/progress.html
+++ b/templates/progress.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="cs">
+<head>
+  <meta charset="UTF-8">
+  <title>Překlad</title>
+  <style>
+    body { font-family: sans-serif; background: #f5f5f5; padding: 40px; }
+    h1 { text-align: center; }
+    .progress-wrapper { max-width: 600px; margin: 40px auto; text-align:center; background:#fff; padding:25px 30px; border-radius:10px; box-shadow:0 2px 8px rgba(0,0,0,0.1); }
+    progress { width: 100%; height: 20px; }
+    .results { max-width: 600px; margin: 30px auto; background:#fff; padding:25px 30px; border-radius:10px; box-shadow:0 2px 8px rgba(0,0,0,0.1); }
+    a.download-link { background:#28a745; color:white; padding:8px 15px; border-radius:5px; text-decoration:none; }
+    a.download-link:hover { background:#1e7e34; }
+  </style>
+</head>
+<body>
+  <h1>Překlad probíhá</h1>
+  <div class="progress-wrapper">
+    <progress id="bar" value="0" max="100"></progress>
+    <p id="status">0%</p>
+  </div>
+  <div id="done" class="results" style="display:none;">
+    <h2>✅ Překlad dokončen</h2>
+    <ul id="links"></ul>
+  </div>
+  <script>
+    const jobId = "{{ job_id }}";
+    function update() {
+      fetch('/progress/' + jobId)
+        .then(r => r.json())
+        .then(data => {
+          const pct = data.percent || 0;
+          document.getElementById('bar').value = pct;
+          document.getElementById('status').textContent = pct + '%';
+          if (data.links) {
+            const ul = document.getElementById('links');
+            ul.innerHTML = '';
+            data.links.forEach(l => {
+              const li = document.createElement('li');
+              li.innerHTML = `<strong>${l[0]}</strong>: <a class="download-link" href="${l[1]}">Stáhnout</a>`;
+              ul.appendChild(li);
+            });
+            document.getElementById('done').style.display = 'block';
+            clearInterval(timer);
+          }
+        });
+    }
+    const timer = setInterval(update, 1000);
+    update();
+  </script>
+</body>
+</html>

--- a/translator/openai_client.py
+++ b/translator/openai_client.py
@@ -7,6 +7,12 @@ import time
 from openai import OpenAI
 from openai.types.chat import ChatCompletionMessageParam
 
+DEFAULT_PROMPT = (
+    "You are a professional translator. "
+    "Translate the following XML-safe text from {from_lang} to {to_lang}. "
+    "Do not change XML tags."
+)
+
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 LANGUAGE_MAP = {
@@ -18,19 +24,20 @@ LANGUAGE_MAP = {
     'hu': 'Hungarian',
 }
 
-def translate_text(text: str, source_lang: str, target_lang: str) -> str:
+def translate_text(
+    text: str,
+    source_lang: str,
+    target_lang: str,
+    system_prompt: str | None = None,
+) -> str:
     """Translate ``text`` from ``source_lang`` to ``target_lang`` using ChatGPT."""
     from_lang = LANGUAGE_MAP.get(source_lang, source_lang)
     to_lang = LANGUAGE_MAP.get(target_lang, target_lang)
+    prompt = (system_prompt or DEFAULT_PROMPT).format(
+        from_lang=from_lang, to_lang=to_lang
+    )
     messages: list[ChatCompletionMessageParam] = [
-        {
-            "role": "system",
-            "content": (
-                "You are a professional translator. "
-                "Translate the following XML-safe text from "
-                f"{from_lang} to {to_lang}. Do not change XML tags."
-            ),
-        },
+        {"role": "system", "content": prompt},
         {"role": "user", "content": text},
     ]
     try:
@@ -44,13 +51,30 @@ def translate_text(text: str, source_lang: str, target_lang: str) -> str:
         print(f"❌ Chyba při překladu: {e}")
         return text
 
-def batch_translate(texts: list[str], target_langs: list[str], source_lang: str) -> dict[str, list[str]]:
-    """Translate a list of texts into multiple languages sequentially."""
+def batch_translate(
+    texts: list[str],
+    target_langs: list[str],
+    source_lang: str,
+    system_prompt: str | None = None,
+    progress_callback: callable | None = None,
+) -> dict[str, list[str]]:
+    """Translate a list of texts into multiple languages sequentially.
+
+    If ``progress_callback`` is provided, it will be called with the number of
+    completed translation steps and the total number of steps after each
+    translation.
+    """
     results = {lang: [] for lang in target_langs}
+    total_steps = len(texts) * len(target_langs)
+    done = 0
     for text in texts:
         for lang in target_langs:
             print(f"Překládám z {source_lang} do {lang}: {text[:40]}...")
-            translation = translate_text(text, source_lang, lang)
+            translation = translate_text(text, source_lang, lang, system_prompt)
             results[lang].append(translation)
+            done += 1
+            if progress_callback:
+                progress_callback(done, total_steps)
             time.sleep(1)
     return results
+


### PR DESCRIPTION
## Summary
- added progress tracking and background worker for translations
- exposed `/progress/<job_id>` endpoint
- created dedicated progress page that updates the bar as translation advances
- replaced language checkboxes with tag-style input using language codes
- support progress callbacks in `batch_translate`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68641b14f7408332933ff10556b41621