### PR TITLE
Implement job progress tracking cleanup

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,7 +4,8 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
-from app import app
+from app import app, JOB_PROGRESS, _cleanup_old_jobs, MAX_FILE_AGE
+import time
 
 
 def test_index_non_idml_file_shows_error_message():
@@ -14,3 +15,14 @@ def test_index_non_idml_file_shows_error_message():
     }
     response = client.post('/', data=data, content_type='multipart/form-data')
     assert "❌ Prosím nahraj platný .idml soubor." in response.get_data(as_text=True)
+
+
+def test_cleanup_old_jobs_removes_stale_entries():
+    JOB_PROGRESS.clear()
+    JOB_PROGRESS['old'] = {'timestamp': time.time() - (MAX_FILE_AGE + 1), 'progress': 0}
+    JOB_PROGRESS['new'] = {'timestamp': time.time(), 'progress': 0}
+
+    _cleanup_old_jobs()
+
+    assert 'old' not in JOB_PROGRESS
+    assert 'new' in JOB_PROGRESS


### PR DESCRIPTION
## Summary
- track timestamp for `JOB_PROGRESS` entries when a job starts
- periodically remove stale jobs via cleanup worker
- test job cleanup routine

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686421ccbd288332b858ca29c1d1bebd