### PR TITLE
Add progress bar and simple password gate

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,13 @@
-from flask import Flask, request, render_template, send_from_directory
+from flask import (
+    Flask,
+    request,
+    render_template,
+    send_from_directory,
+    redirect,
+    url_for,
+    session,
+    jsonify,
+)
 import os
 from werkzeug.utils import secure_filename
 import contextlib
@@ -22,6 +31,8 @@ import time
 import threading
 
 app = Flask(__name__)
+app.secret_key = os.environ.get("FLASK_SECRET_KEY", "devsecret")
+PASSWORD = os.environ.get("APP_PASSWORD", "banana")
 app.config['UPLOAD_FOLDER'] = 'uploads'
 app.config['RESULT_FOLDER'] = 'results'
 
@@ -70,6 +81,17 @@ def _cleanup_worker() -> None:
 
 threading.Thread(target=_cleanup_worker, daemon=True).start()
 
+
+@app.before_request
+def _require_login():
+    if app.config.get("TESTING"):
+        return
+    if request.endpoint in {"login", "static"}:
+        return
+    if session.get("logged_in"):
+        return
+    return redirect(url_for("login"))
+
 LANGUAGE_NAMES = {
     'cs': 'Čeština',
     'sk': 'Slovenština',
@@ -79,8 +101,93 @@ LANGUAGE_NAMES = {
     'hu': 'Maďarština'
 }
 
+
+def _run_translation_job(
+    job_id: str,
+    file_path: str,
+    base_name: str,
+    selected_languages: list[str],
+    source_lang: str,
+    system_prompt: str | None,
+) -> None:
+    extract_dir = os.path.join(app.config['UPLOAD_FOLDER'], 'unpacked_original')
+    extract_idml(file_path, extract_dir)
+
+    story_files = find_story_files(extract_dir)
+
+    all_contents = []
+    all_texts = []
+    for story_path in story_files:
+        tree = load_story_xml(story_path)
+        contents = extract_content_elements(tree)
+        all_contents.append((story_path, tree, contents))
+        for _, text in contents:
+            all_texts.append(text)
+
+    def _progress(pct: int) -> None:
+        JOB_PROGRESS[job_id]["progress"] = int(pct * 0.9)
+
+    translations_by_lang = batch_translate(
+        all_texts,
+        selected_languages,
+        source_lang,
+        system_prompt,
+        progress_callback=_progress,
+    )
+
+    for lang in selected_languages:
+        lang_dir = os.path.join(app.config['UPLOAD_FOLDER'], f'unpacked_{lang}')
+        copy_unpacked_dir(extract_dir, lang_dir)
+
+        index = 0
+        for story_path, _, contents in all_contents:
+            rel_path = os.path.relpath(story_path, extract_dir)
+            new_story_path = os.path.join(lang_dir, rel_path)
+
+            tree = load_story_xml(new_story_path)
+            local_contents = extract_content_elements(tree)
+
+            translations = translations_by_lang[lang][index : index + len(local_contents)]
+            update_content_elements(local_contents, translations)
+            save_story_xml(tree, new_story_path)
+
+            index += len(local_contents)
+
+        output_file = f"{base_name}-{lang}.idml"
+        output_path = os.path.join(app.config['RESULT_FOLDER'], output_file)
+        repackage_idml(lang_dir, output_path)
+
+    JOB_PROGRESS[job_id]["progress"] = 100
+    JOB_PROGRESS[job_id]["links"] = [
+        (lang, f'/download/{base_name}-{lang}.idml')
+        for lang in selected_languages
+    ]
+
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    error = None
+    if request.method == 'POST':
+        if request.form.get('password') == PASSWORD:
+            session['logged_in'] = True
+            return redirect(url_for('index'))
+        error = 'Nesprávné heslo.'
+    return render_template('login.html', error=error)
+
 @app.route('/', methods=['GET', 'POST'])
 def index():
+    job_id = request.args.get('job')
+    if job_id:
+        info = JOB_PROGRESS.get(job_id)
+        if info and info.get('progress') == 100:
+            return render_template(
+                'index.html',
+                links=info.get('links'),
+                lang_names=LANGUAGE_NAMES,
+                prompt_text=info.get('prompt', DEFAULT_PROMPT),
+            )
+        return render_template('index.html', job_id=job_id, prompt_text=DEFAULT_PROMPT)
+
     if request.method == 'POST':
         uploaded_file = request.files.get('idml_file')
         selected_languages = request.form.getlist('languages')
@@ -94,74 +201,35 @@ def index():
             selected_languages.remove(source_lang)
 
         job_id = str(uuid.uuid4())
-        JOB_PROGRESS[job_id] = {"timestamp": time.time(), "progress": 0}
+        JOB_PROGRESS[job_id] = {"timestamp": time.time(), "progress": 0, "prompt": system_prompt or DEFAULT_PROMPT}
 
         filename = secure_filename(uploaded_file.filename)
         file_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
         uploaded_file.save(file_path)
-
         base_name = os.path.splitext(filename)[0]
-        extract_dir = os.path.join(app.config['UPLOAD_FOLDER'], 'unpacked_original')
-        extract_idml(file_path, extract_dir)
 
-        story_files = find_story_files(extract_dir)
-
-        all_contents = []
-        all_texts = []
-        for story_path in story_files:
-            tree = load_story_xml(story_path)
-            contents = extract_content_elements(tree)
-            all_contents.append((story_path, tree, contents))
-            for _, text in contents:
-                all_texts.append(text)
-
-        translations_by_lang = batch_translate(
-            all_texts,
-            selected_languages,
-            source_lang,
-            system_prompt,
+        thread = threading.Thread(
+            target=_run_translation_job,
+            args=(job_id, file_path, base_name, selected_languages, source_lang, system_prompt),
+            daemon=True,
         )
+        thread.start()
 
-        for lang in selected_languages:
-            lang_dir = os.path.join(app.config['UPLOAD_FOLDER'], f'unpacked_{lang}')
-            copy_unpacked_dir(extract_dir, lang_dir)
-
-            index = 0
-            for story_path, _, contents in all_contents:
-                rel_path = os.path.relpath(story_path, extract_dir)
-                new_story_path = os.path.join(lang_dir, rel_path)
-
-                tree = load_story_xml(new_story_path)
-                local_contents = extract_content_elements(tree)
-
-                translations = translations_by_lang[lang][index : index + len(local_contents)]
-                update_content_elements(local_contents, translations)
-                save_story_xml(tree, new_story_path)
-
-                index += len(local_contents)
-
-            output_file = f"{base_name}-{lang}.idml"
-            output_path = os.path.join(app.config['RESULT_FOLDER'], output_file)
-            repackage_idml(lang_dir, output_path)
-
-        JOB_PROGRESS[job_id]["progress"] = 100
-
-        links = [
-            (lang, f'/download/{base_name}-{lang}.idml')
-            for lang in selected_languages
-        ]
-        return render_template(
-            'index.html',
-            links=links,
-            lang_names=LANGUAGE_NAMES,
-            prompt_text=system_prompt or DEFAULT_PROMPT
-        )
+        return render_template('index.html', job_id=job_id, prompt_text=system_prompt or DEFAULT_PROMPT)
 
     return render_template('index.html', prompt_text=DEFAULT_PROMPT)
 
 @app.route('/download/<filename>')
 def download_file(filename):
     return send_from_directory(app.config['RESULT_FOLDER'], filename, as_attachment=True)
+
+
+@app.route('/progress/<job_id>')
+def progress(job_id: str):
+    info = JOB_PROGRESS.get(job_id)
+    if not info:
+        return jsonify({'progress': 100, 'links': []})
+    return jsonify({'progress': info.get('progress', 0), 'links': info.get('links')})
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,18 +23,50 @@
       margin-top: 15px;
       font-weight: bold;
     }
-    select, input[type="file"], button {
+    select, input[type="file"], button, textarea {
       margin-top: 5px;
       padding: 8px;
       width: 100%;
       box-sizing: border-box;
     }
-    .checkbox-group {
-      margin-top: 10px;
+    textarea {
+      border-radius: 5px;
+      border: 1px solid #ccc;
     }
-    .checkbox-group label {
-      font-weight: normal;
-      display: block;
+    .tag-group {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 5px;
+      margin-top: 5px;
+    }
+    .tag {
+      position: relative;
+    }
+    .tag input {
+      display: none;
+    }
+    .tag span {
+      padding: 5px 10px;
+      background: #eee;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+    .tag input:checked + span {
+      background: #007bff;
+      color: #fff;
+    }
+    .progress-bar {
+      width: 100%;
+      background: #e0e0e0;
+      border-radius: 5px;
+      overflow: hidden;
+      height: 20px;
+      margin-top: 5px;
+    }
+    .progress-fill {
+      height: 100%;
+      background: #007bff;
+      width: 0;
     }
     button {
       background-color: #007bff;
@@ -92,26 +124,33 @@
     <input type="file" name="idml_file" accept=".idml" required>
 
     <label for="source_lang">Zdrojový jazyk:</label>
-    <select name="source_lang" required>
-      <option value="cs">Čeština</option>
-      <option value="en">Angličtina</option>
-      <option value="de">Němčina</option>
-      <option value="sk">Slovenština</option>
-      <option value="pl">Polština</option>
-      <option value="hu">Maďarština</option>
-    </select>
+    <div class="tag-group">
+      <label class="tag"><input type="radio" name="source_lang" value="cs" required><span>Čeština</span></label>
+      <label class="tag"><input type="radio" name="source_lang" value="en"><span>Angličtina</span></label>
+      <label class="tag"><input type="radio" name="source_lang" value="de"><span>Němčina</span></label>
+      <label class="tag"><input type="radio" name="source_lang" value="sk"><span>Slovenština</span></label>
+      <label class="tag"><input type="radio" name="source_lang" value="pl"><span>Polština</span></label>
+      <label class="tag"><input type="radio" name="source_lang" value="hu"><span>Maďarština</span></label>
+    </div>
 
     <label for="languages">Cílové jazyky:</label>
-    <div class="checkbox-group">
-      <label><input type="checkbox" name="languages" value="en"> Angličtina</label>
-      <label><input type="checkbox" name="languages" value="de"> Němčina</label>
-      <label><input type="checkbox" name="languages" value="sk"> Slovenština</label>
-      <label><input type="checkbox" name="languages" value="pl"> Polština</label>
-      <label><input type="checkbox" name="languages" value="hu"> Maďarština</label>
+    <div class="tag-group">
+      <label class="tag"><input type="checkbox" name="languages" value="en"><span>Angličtina</span></label>
+      <label class="tag"><input type="checkbox" name="languages" value="de"><span>Němčina</span></label>
+      <label class="tag"><input type="checkbox" name="languages" value="sk"><span>Slovenština</span></label>
+      <label class="tag"><input type="checkbox" name="languages" value="pl"><span>Polština</span></label>
+      <label class="tag"><input type="checkbox" name="languages" value="hu"><span>Maďarština</span></label>
     </div>
 
     <label for="prompt">AI Prompt:</label>
     <textarea name="prompt" rows="4">{{ prompt_text }}</textarea>
+
+    {% if job_id %}
+    <label>Průběh překladu:</label>
+    <div class="progress-bar">
+      <div class="progress-fill" id="progress-fill"></div>
+    </div>
+    {% endif %}
 
     <button type="submit">Nahrát a přeložit</button>
   </form>
@@ -133,5 +172,26 @@
   <div class="footer">
     &copy; 2025 IDML Translator – powered by Flask & ChatGPT API
   </div>
+  {% if job_id %}
+  <script>
+    const jobId = '{{ job_id }}';
+    const fill = document.getElementById('progress-fill');
+    if (jobId && fill) {
+      function poll() {
+        fetch('/progress/' + jobId)
+          .then(r => r.json())
+          .then(data => {
+            fill.style.width = data.progress + '%';
+            if (data.progress >= 100 && data.links) {
+              window.location.href = '/?job=' + jobId;
+            } else {
+              setTimeout(poll, 2000);
+            }
+          });
+      }
+      poll();
+    }
+  </script>
+  {% endif %}
 </body>
 </html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="cs">
+<head>
+  <meta charset="UTF-8">
+  <title>Přihlášení</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      background: #f5f5f5;
+      padding: 40px;
+    }
+    form {
+      max-width: 400px;
+      margin: 0 auto;
+      background: #fff;
+      padding: 25px 30px;
+      border-radius: 10px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+    label {
+      display: block;
+      margin-top: 15px;
+      font-weight: bold;
+    }
+    input[type="password"], button {
+      margin-top: 5px;
+      padding: 8px;
+      width: 100%;
+      box-sizing: border-box;
+    }
+    button {
+      background-color: #007bff;
+      color: white;
+      border: none;
+      border-radius: 5px;
+      margin-top: 20px;
+      cursor: pointer;
+    }
+    button:hover {
+      background-color: #0056b3;
+    }
+    .error {
+      max-width: 400px;
+      margin: 20px auto;
+      background: #f8d7da;
+      color: #721c24;
+      text-align: center;
+      padding: 15px 20px;
+      border-radius: 5px;
+      border: 1px solid #f5c6cb;
+    }
+  </style>
+</head>
+<body>
+  {% if error %}
+  <div class="error">{{ error }}</div>
+  {% endif %}
+  <form method="POST">
+    <label for="password">Heslo:</label>
+    <input type="password" name="password" required>
+    <button type="submit">Přihlásit se</button>
+  </form>
+</body>
+</html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,6 +5,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 from app import app, JOB_PROGRESS, _cleanup_old_jobs, MAX_FILE_AGE
+app.config['TESTING'] = True
 import time
 
 

--- a/translator/openai_client.py
+++ b/translator/openai_client.py
@@ -56,14 +56,24 @@ def batch_translate(
     target_langs: list[str],
     source_lang: str,
     system_prompt: str | None = None,
+    progress_callback: callable | None = None,
 ) -> dict[str, list[str]]:
-    """Translate a list of texts into multiple languages sequentially."""
+    """Translate a list of texts into multiple languages sequentially.
+
+    ``progress_callback`` will be called with the percentage completed (0-100)
+    after each translation step if provided.
+    """
     results = {lang: [] for lang in target_langs}
+    total = max(1, len(texts) * len(target_langs))
+    done = 0
     for text in texts:
         for lang in target_langs:
             print(f"Překládám z {source_lang} do {lang}: {text[:40]}...")
             translation = translate_text(text, source_lang, lang, system_prompt)
             results[lang].append(translation)
+            done += 1
+            if progress_callback:
+                progress_callback(int(done / total * 100))
             time.sleep(1)
     return results
 


### PR DESCRIPTION
## Summary
- password gate via `/login`
- progress bar with job polling and async worker
- tag-style language selection and improved textarea
- tests set `TESTING` config for auth bypass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686423cc0b28833296db67d701e01874