### PR TITLE
Improve translation workflow

### DIFF
--- a/app.py
+++ b/app.py
@@ -82,6 +82,12 @@ def _cleanup_worker() -> None:
 threading.Thread(target=_cleanup_worker, daemon=True).start()
 
 
+@app.template_filter('datetimeformat')
+def datetimeformat(value: float) -> str:
+    """Format a timestamp for display."""
+    return time.strftime('%Y-%m-%d %H:%M', time.localtime(value))
+
+
 @app.before_request
 def _require_login():
     if app.config.get("TESTING"):
@@ -92,76 +98,100 @@ def _require_login():
         return
     return redirect(url_for("login"))
 
+try:
+    import pycountry  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    pycountry = None
+
 LANGUAGE_NAMES = {
-    'cs': 'Čeština',
-    'sk': 'Slovenština',
-    'pl': 'Polština',
-    'en': 'Angličtina',
-    'de': 'Němčina',
-    'hu': 'Maďarština'
+    'cs': 'Czech',
+    'sk': 'Slovak',
+    'pl': 'Polish',
+    'en': 'English',
+    'de': 'German',
+    'hu': 'Hungarian',
 }
+if pycountry:
+    LANGUAGE_NAMES.update(
+        {
+            lang.alpha_2: lang.name
+            for lang in pycountry.languages
+            if hasattr(lang, "alpha_2")
+        }
+    )
 
 
 def _run_translation_job(
     job_id: str,
-    file_path: str,
-    base_name: str,
+    files: list[tuple[str, str]],
     selected_languages: list[str],
     source_lang: str,
     system_prompt: str | None,
 ) -> None:
-    extract_dir = os.path.join(app.config['UPLOAD_FOLDER'], 'unpacked_original')
-    extract_idml(file_path, extract_dir)
+    links: list[tuple[str, str, str]] = []  # (lang, url, filename)
+    total_steps = 0
+    for file_path, _ in files:
+        extract_dir = os.path.join(app.config['UPLOAD_FOLDER'], 'unpacked_original')
+        extract_idml(file_path, extract_dir)
+        total_steps += len(find_story_files(extract_dir))
 
-    story_files = find_story_files(extract_dir)
+    steps_done = 0
 
-    all_contents = []
-    all_texts = []
-    for story_path in story_files:
-        tree = load_story_xml(story_path)
-        contents = extract_content_elements(tree)
-        all_contents.append((story_path, tree, contents))
-        for _, text in contents:
-            all_texts.append(text)
+    for file_path, base_name in files:
+        extract_dir = os.path.join(app.config['UPLOAD_FOLDER'], 'unpacked_original')
+        extract_idml(file_path, extract_dir)
 
-    def _progress(pct: int) -> None:
-        JOB_PROGRESS[job_id]["progress"] = int(pct * 0.9)
+        story_files = find_story_files(extract_dir)
 
-    translations_by_lang = batch_translate(
-        all_texts,
-        selected_languages,
-        source_lang,
-        system_prompt,
-        progress_callback=_progress,
-    )
+        all_contents = []
+        all_texts = []
+        for story_path in story_files:
+            tree = load_story_xml(story_path)
+            contents = extract_content_elements(tree)
+            all_contents.append((story_path, tree, contents))
+            for _, text in contents:
+                all_texts.append(text)
 
-    for lang in selected_languages:
-        lang_dir = os.path.join(app.config['UPLOAD_FOLDER'], f'unpacked_{lang}')
-        copy_unpacked_dir(extract_dir, lang_dir)
+        def _progress(pct: int) -> None:
+            JOB_PROGRESS[job_id]["progress"] = int(pct * 0.9)
 
-        index = 0
-        for story_path, _, contents in all_contents:
-            rel_path = os.path.relpath(story_path, extract_dir)
-            new_story_path = os.path.join(lang_dir, rel_path)
+        translations_by_lang = batch_translate(
+            all_texts,
+            selected_languages,
+            source_lang,
+            system_prompt,
+            progress_callback=_progress,
+        )
 
-            tree = load_story_xml(new_story_path)
-            local_contents = extract_content_elements(tree)
+        for lang in selected_languages:
+            lang_dir = os.path.join(app.config['UPLOAD_FOLDER'], f'unpacked_{lang}')
+            copy_unpacked_dir(extract_dir, lang_dir)
 
-            translations = translations_by_lang[lang][index : index + len(local_contents)]
-            update_content_elements(local_contents, translations)
-            save_story_xml(tree, new_story_path)
+            index = 0
+            for story_path, _, contents in all_contents:
+                rel_path = os.path.relpath(story_path, extract_dir)
+                new_story_path = os.path.join(lang_dir, rel_path)
 
-            index += len(local_contents)
+                tree = load_story_xml(new_story_path)
+                local_contents = extract_content_elements(tree)
 
-        output_file = f"{base_name}-{lang}.idml"
-        output_path = os.path.join(app.config['RESULT_FOLDER'], output_file)
-        repackage_idml(lang_dir, output_path)
+                translations = translations_by_lang[lang][index : index + len(local_contents)]
+                update_content_elements(local_contents, translations)
+                save_story_xml(tree, new_story_path)
+
+                index += len(local_contents)
+
+            output_file = f"{base_name}-{lang}.idml"
+            output_path = os.path.join(app.config['RESULT_FOLDER'], output_file)
+            repackage_idml(lang_dir, output_path)
+            links.append((lang, f'/download/{output_file}', output_file))
+
+        steps_done += len(story_files)
+        JOB_PROGRESS[job_id]["progress"] = int((steps_done / max(1, total_steps)) * 100)
 
     JOB_PROGRESS[job_id]["progress"] = 100
-    JOB_PROGRESS[job_id]["links"] = [
-        (lang, f'/download/{base_name}-{lang}.idml')
-        for lang in selected_languages
-    ]
+    JOB_PROGRESS[job_id]["links"] = links
+    JOB_PROGRESS[job_id]["expires_at"] = JOB_PROGRESS[job_id]["timestamp"] + MAX_FILE_AGE
 
 
 @app.route('/login', methods=['GET', 'POST'])
@@ -176,25 +206,13 @@ def login():
 
 @app.route('/', methods=['GET', 'POST'])
 def index():
-    job_id = request.args.get('job')
-    if job_id:
-        info = JOB_PROGRESS.get(job_id)
-        if info and info.get('progress') == 100:
-            return render_template(
-                'index.html',
-                links=info.get('links'),
-                lang_names=LANGUAGE_NAMES,
-                prompt_text=info.get('prompt', DEFAULT_PROMPT),
-            )
-        return render_template('index.html', job_id=job_id, prompt_text=DEFAULT_PROMPT)
-
     if request.method == 'POST':
-        uploaded_file = request.files.get('idml_file')
+        uploaded_files = request.files.getlist('idml_files')
         selected_languages = request.form.getlist('languages')
         source_lang = request.form.get('source_lang')
         system_prompt = request.form.get('prompt', '').strip() or None
 
-        if not uploaded_file or not uploaded_file.filename.endswith('.idml'):
+        if not uploaded_files or any(not f.filename.endswith('.idml') for f in uploaded_files):
             return render_template('index.html', error="❌ Prosím nahraj platný .idml soubor.")
 
         if source_lang in selected_languages:
@@ -203,19 +221,35 @@ def index():
         job_id = str(uuid.uuid4())
         JOB_PROGRESS[job_id] = {"timestamp": time.time(), "progress": 0, "prompt": system_prompt or DEFAULT_PROMPT}
 
-        filename = secure_filename(uploaded_file.filename)
-        file_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
-        uploaded_file.save(file_path)
-        base_name = os.path.splitext(filename)[0]
+        file_info = []
+        for uploaded_file in uploaded_files:
+            filename = secure_filename(uploaded_file.filename)
+            file_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+            uploaded_file.save(file_path)
+            base_name = os.path.splitext(filename)[0]
+            file_info.append((file_path, base_name))
 
         thread = threading.Thread(
             target=_run_translation_job,
-            args=(job_id, file_path, base_name, selected_languages, source_lang, system_prompt),
+            args=(job_id, file_info, selected_languages, source_lang, system_prompt),
             daemon=True,
         )
         thread.start()
 
         return render_template('index.html', job_id=job_id, prompt_text=system_prompt or DEFAULT_PROMPT)
+
+    job_id = request.args.get('job')
+    if job_id:
+        info = JOB_PROGRESS.get(job_id)
+        if info and info.get('progress') == 100:
+            return render_template(
+                'index.html',
+                links=info.get('links'),
+                lang_names=LANGUAGE_NAMES,
+                expires_at=info.get('expires_at'),
+                prompt_text=info.get('prompt', DEFAULT_PROMPT),
+            )
+        return render_template('index.html', job_id=job_id, prompt_text=DEFAULT_PROMPT)
 
     return render_template('index.html', prompt_text=DEFAULT_PROMPT)
 
@@ -229,7 +263,7 @@ def progress(job_id: str):
     info = JOB_PROGRESS.get(job_id)
     if not info:
         return jsonify({'progress': 100, 'links': []})
-    return jsonify({'progress': info.get('progress', 0), 'links': info.get('links')})
+    return jsonify({'progress': info.get('progress', 0), 'links': info.get('links'), 'expires_at': info.get('expires_at')})
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ tqdm==4.67.1
 typing-inspection==0.4.1
 typing_extensions==4.14.0
 Werkzeug==3.1.3
+pycountry==23.12.11

--- a/templates/index.html
+++ b/templates/index.html
@@ -119,9 +119,9 @@
   <div class="error">{{ error }}</div>
   {% endif %}
 
-  <form method="POST" enctype="multipart/form-data">
-    <label for="idml_file">Vyber IDML soubor:</label>
-    <input type="file" name="idml_file" accept=".idml" required>
+  <form method="POST" action="/" enctype="multipart/form-data">
+    <label for="idml_files">Vyber IDML soubory:</label>
+    <input type="file" name="idml_files" accept=".idml" multiple required>
 
     <label for="source_lang">Zdrojový jazyk:</label>
     <div class="tag-group">
@@ -159,9 +159,12 @@
   {% if links %}
   <div class="results">
     <h2>✅ Překlad dokončen</h2>
+    {% if expires_at %}
+    <p>Soubor bude dostupný do: {{ expires_at | datetimeformat }}</p>
+    {% endif %}
     <ul>
-      {% for lang_code, file_url in links %}
-        <li><strong>{{ lang_names[lang_code] }}:</strong>
+      {% for lang_code, file_url, fname in links %}
+        <li><strong>{{ lang_names.get(lang_code, lang_code) }} ({{ fname }}):</strong>
           <a class="download-link" href="{{ file_url }}">Stáhnout</a>
         </li>
       {% endfor %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,7 +12,7 @@ import time
 def test_index_non_idml_file_shows_error_message():
     client = app.test_client()
     data = {
-        'idml_file': (io.BytesIO(b'dummy'), 'test.txt')
+        'idml_files': [(io.BytesIO(b'dummy'), 'test.txt')]
     }
     response = client.post('/', data=data, content_type='multipart/form-data')
     assert "❌ Prosím nahraj platný .idml soubor." in response.get_data(as_text=True)

--- a/translator/openai_client.py
+++ b/translator/openai_client.py
@@ -7,6 +7,11 @@ import time
 from openai import OpenAI
 from openai.types.chat import ChatCompletionMessageParam
 
+try:
+    import pycountry  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    pycountry = None
+
 DEFAULT_PROMPT = (
     "You are a professional translator. "
     "Translate the following XML-safe text from {from_lang} to {to_lang}. "
@@ -15,14 +20,15 @@ DEFAULT_PROMPT = (
 
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
-LANGUAGE_MAP = {
-    'cs': 'Czech',
-    'sk': 'Slovak',
-    'pl': 'Polish',
-    'en': 'English',
-    'de': 'German',
-    'hu': 'Hungarian',
-}
+LANGUAGE_MAP: dict[str, str] = {}
+if pycountry:
+    LANGUAGE_MAP.update(
+        {
+            lang.alpha_2: lang.name
+            for lang in pycountry.languages
+            if hasattr(lang, "alpha_2")
+        }
+    )
 
 def translate_text(
     text: str,


### PR DESCRIPTION
## Summary
- support uploading multiple IDML files
- fix translation form action so follow-up jobs work
- show expiration time and file names in results
- load language list dynamically using pycountry
- expose progress expiration via API
- handle missing pycountry gracefully
- update tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686426ac03448332a971c605a010df5f