### PR TITLE
Add auto-scroll to translation list

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -239,5 +239,14 @@
     }
   </script>
   {% endif %}
+  <script>
+    // Scroll to the list of available translations on page load
+    window.addEventListener('DOMContentLoaded', () => {
+      const results = document.querySelector('.results');
+      if (results) {
+        results.scrollIntoView({ behavior: 'smooth' });
+      }
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- scroll to the list of finished translations once the page loads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68642ec3759c83328cfed164aed1b60b