### PR TITLE
Add dynamic translations loading

### DIFF
--- a/app.py
+++ b/app.py
@@ -286,6 +286,21 @@ def progress(job_id: str):
     return jsonify({'progress': info.get('progress', 0), 'links': info.get('links'), 'expires_at': info.get('expires_at')})
 
 
+@app.route('/translations')
+def translations():
+    completed_jobs = [
+        {
+            "id": jid,
+            "links": info.get("links", []),
+            "timestamp": info.get("timestamp", 0),
+        }
+        for jid, info in JOB_PROGRESS.items()
+        if info.get("progress") == 100
+    ]
+    completed_jobs.sort(key=lambda j: j["timestamp"], reverse=True)
+    return jsonify(completed_jobs)
+
+
 @app.route('/remove/<job_id>', methods=['POST'])
 def remove_job(job_id: str):
     info = JOB_PROGRESS.pop(job_id, None)

--- a/templates/index.html
+++ b/templates/index.html
@@ -259,10 +259,10 @@
     <button type="submit">Nahrát a přeložit</button>
   </form>
 
-  {% if completed_jobs %}
   <div class="results">
     <h2>✅ Dostupné překlady</h2>
-    <ul>
+    <div id="translations-loading" style="display:none">Načítám...</div>
+    <ul id="translation-list">
       {% for j in completed_jobs %}
       <div class="job">
         <div class="job-header">
@@ -283,7 +283,6 @@
       {% endfor %}
     </ul>
   </div>
-  {% endif %}
 
   <div class="footer">
     &copy; 2025 IDML Translator – powered by Unicorns & Magic
@@ -310,6 +309,48 @@
     }
   </script>
   {% endif %}
+  <script>
+    async function loadTranslations() {
+      const list = document.getElementById('translation-list');
+      const loading = document.getElementById('translations-loading');
+      if (!list || !loading) return;
+      loading.style.display = 'block';
+      try {
+        const res = await fetch('/translations');
+        if (!res.ok) throw new Error();
+        const jobs = await res.json();
+        list.innerHTML = '';
+        for (const job of jobs) {
+          const jobDiv = document.createElement('div');
+          jobDiv.className = 'job';
+          const header = document.createElement('div');
+          header.className = 'job-header';
+          header.innerHTML = `<span>${new Date(job.timestamp * 1000).toISOString().slice(0,16).replace('T',' ')}</span>`;
+          const removeForm = document.createElement('form');
+          removeForm.method = 'post';
+          removeForm.action = `/remove/${job.id}`;
+          removeForm.className = 'remove-form';
+          removeForm.innerHTML = '<button class="remove-btn" type="submit" title="Smazat">❌</button>';
+          jobDiv.appendChild(header);
+          jobDiv.appendChild(removeForm);
+          const ul = document.createElement('ul');
+          ul.className = 'job-files';
+          for (const [lang, url, fname] of job.links) {
+            const li = document.createElement('li');
+            li.innerHTML = `<strong>${lang} (${fname}):</strong> <a class="download-link" href="${url}">Stáhnout</a>`;
+            ul.appendChild(li);
+          }
+          jobDiv.appendChild(ul);
+          list.appendChild(jobDiv);
+        }
+      } catch (err) {
+        alert('Nepodařilo se načíst dostupné překlady.');
+      } finally {
+        loading.style.display = 'none';
+      }
+    }
+    window.addEventListener('DOMContentLoaded', loadTranslations);
+  </script>
   <script>
     window.addEventListener('DOMContentLoaded', () => {
       const results = document.querySelector('.results');

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -34,3 +34,18 @@ def test_index_template_has_autoscroll_script():
     with open(path, encoding='utf-8') as f:
         html = f.read()
     assert 'scrollIntoView' in html
+
+
+def test_translations_endpoint_returns_json():
+    JOB_PROGRESS.clear()
+    JOB_PROGRESS['job'] = {
+        'progress': 100,
+        'timestamp': 1,
+        'links': [('cs', '/download/file.idml', 'file.idml')],
+    }
+    client = app.test_client()
+    response = client.get('/translations')
+    assert response.status_code == 200
+    data = response.get_json()
+    assert isinstance(data, list)
+    assert data[0]['id'] == 'job'


### PR DESCRIPTION
## Summary
- provide `/translations` endpoint to return JSON list of completed jobs
- show translations container on index page and add loader
- load available translations asynchronously via fetch
- test new endpoint

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864b6629bcc83328ad4681d239d5e43