### PR TITLE
Improve batch translation

### DIFF
--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -5,17 +5,24 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 from translator import openai_client
 
 
-def test_batch_translate_uses_cache(monkeypatch):
+def test_batch_translate_batches_and_caches(monkeypatch):
     calls = []
 
     def fake_create(*args, **kwargs):
+        prompt = kwargs['messages'][-1]['content']
+        lines = [l for l in prompt.splitlines() if l.strip() and l.strip()[0].isdigit()]
+        pieces = [l.split('.', 1)[1].strip() if '.' in l else l for l in lines]
+
         class M:
             pass
+
         resp = M()
         resp.choices = [M()]
         resp.choices[0].message = M()
-        resp.choices[0].message.content = kwargs['messages'][-1]['content'] + '_t'
-        calls.append(kwargs['messages'][-1]['content'])
+        resp.choices[0].message.content = "\n".join(
+            f"{i+1}. {p}_t" for i, p in enumerate(pieces)
+        )
+        calls.append(prompt)
         return resp
 
     monkeypatch.setattr(openai_client.client.chat.completions, 'create', fake_create)
@@ -23,5 +30,7 @@ def test_batch_translate_uses_cache(monkeypatch):
     texts = ['Hello', 'Hello', 'World']
     result = openai_client.batch_translate(texts, ['cs'], 'en')
     assert result['cs'] == ['Hello_t', 'Hello_t', 'World_t']
-    # two unique texts -> two API calls
-    assert calls == ['Hello', 'World']
+    # both unique segments should be sent in one request
+    assert len(calls) == 1
+    assert '1. Hello' in calls[0]
+    assert '2. World' in calls[0]


### PR DESCRIPTION
## Summary
- batch unique segments for OpenAI requests
- parse numbered batch output for translations
- ensure repeated segments reuse the cache
- test batching and caching in `batch_translate`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864bf5d74848332a8511e9dfa3f02d9