### PR TITLE
Add model selection to translator

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ A simple Flask application for translating IDML (InDesign Markup Language) files
    ```bash
    pip install -r requirements.txt
    ```
-2. Set the environment variables `OPENAI_API_KEY`, and optionally `FLASK_SECRET_KEY` and `APP_PASSWORD`.
+2. Set the environment variables `OPENAI_API_KEY`, and optionally `FLASK_SECRET_KEY`, `APP_PASSWORD` and `OPENAI_MODEL` (default `gpt-4`).
 3. Run the app:
    ```bash
    python app.py
    ```
+
+The web UI includes a drop-down to select the chat model for each translation job.
 
 ## Tests
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -246,6 +246,13 @@
       <label class="tag"><input type="checkbox" name="languages" value="hu"><span>Maďarština</span></label>
     </div>
 
+    <label for="model">Model:</label>
+    <select name="model">
+      {% for m in ['gpt-3.5-turbo', 'gpt-4', 'gpt-4o'] %}
+      <option value="{{ m }}" {% if selected_model == m %}selected{% endif %}>{{ m }}</option>
+      {% endfor %}
+    </select>
+
     <label for="prompt">AI Prompt:</label>
     <textarea name="prompt" rows="4">{{ prompt_text }}</textarea>
 


### PR DESCRIPTION
## Summary
- make OpenAI client functions accept a `model` parameter
- thread job and index route choose model from request or environment
- add model selector to web interface
- document new configuration option
- update tests for model argument

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864c53658488332970a2c875b18d5b0