### PR TITLE
Add estimator and model selection tests

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,9 +1,14 @@
 import io
 import os
 import sys
+import zipfile
+import threading
+
+from translator import token_estimator
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
+import app as app_module
 from app import app, JOB_PROGRESS, _cleanup_old_jobs, MAX_FILE_AGE
 app.config['TESTING'] = True
 import time
@@ -49,3 +54,56 @@ def test_translations_endpoint_returns_json():
     data = response.get_json()
     assert isinstance(data, list)
     assert data[0]['id'] == 'job'
+
+
+def _create_idml(path: str) -> None:
+    with zipfile.ZipFile(path, 'w') as zf:
+        zf.writestr('mimetype', '')
+        zf.writestr('Stories/story.xml', '<Root><Content>Hello</Content></Root>')
+
+
+def test_index_passes_selected_model(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_run(job_id, files, langs, src, prompt, model):
+        called['model'] = model
+
+    class DummyThread:
+        def __init__(self, target, args=(), daemon=None):
+            self.target = target
+            self.args = args
+        def start(self):
+            self.target(*self.args)
+
+    monkeypatch.setattr(app_module, '_run_translation_job', fake_run)
+    monkeypatch.setattr(threading, 'Thread', DummyThread)
+
+    idml_path = tmp_path / 't.idml'
+    _create_idml(idml_path)
+
+    client = app.test_client()
+    data = {
+        'idml_files': [(open(idml_path, 'rb'), 't.idml')],
+        'languages': 'cs',
+        'source_lang': 'en',
+        'model': 'gpt-3.5-turbo',
+    }
+    client.post('/', data=data, content_type='multipart/form-data')
+    assert called.get('model') == 'gpt-3.5-turbo'
+
+
+def test_estimate_route(monkeypatch, tmp_path):
+    monkeypatch.setattr(app_module, 'count_tokens', lambda texts, model: 1000)
+    idml_path = tmp_path / 'e.idml'
+    _create_idml(idml_path)
+    client = app.test_client()
+    data = {
+        'idml_files': [(open(idml_path, 'rb'), 'e.idml')],
+        'languages': ['cs', 'de'],
+        'model': 'gpt-4o',
+    }
+    resp = client.post('/estimate', data=data, content_type='multipart/form-data')
+    assert resp.status_code == 200
+    result = resp.get_json()
+    expected = round(token_estimator.estimate_cost(1000, 'gpt-4o', 2), 4)
+    assert result == {'tokens': 1000, 'cost': expected}

--- a/tests/test_token_estimator.py
+++ b/tests/test_token_estimator.py
@@ -1,10 +1,35 @@
+import tiktoken
+import pytest
 from translator.token_estimator import count_tokens, estimate_cost, MODEL_RATES
 
 
-def test_estimate_cost_matches_manual():
+class DummyEncoder:
+    def encode(self, text: str):
+        return text.split()
+
+
+def test_estimate_cost_matches_manual(monkeypatch):
+    monkeypatch.setattr(tiktoken, "get_encoding", lambda name: DummyEncoder())
     texts = ["Hello world", "Bye"]
     model = "gpt-3.5-turbo"
     tokens = count_tokens(texts, model)
     cost = estimate_cost(tokens, model, 2)
     assert cost == tokens / 1000 * MODEL_RATES[model] * 2
+
+
+def test_count_tokens_uses_encoder(monkeypatch):
+    monkeypatch.setattr(tiktoken, "get_encoding", lambda name: DummyEncoder())
+    assert count_tokens(["a b", "c"], "gpt-4") == 3
+
+
+def test_count_tokens_returns_zero_on_error(monkeypatch):
+    def boom(name):
+        raise RuntimeError("nope")
+    monkeypatch.setattr(tiktoken, "get_encoding", boom)
+    assert count_tokens(["hi"], "gpt-4") == 0
+
+
+def test_estimate_cost_default_rate():
+    cost = estimate_cost(1000, "unknown", 3)
+    assert cost == (1000 / 1000) * 0.03 * 3
 


### PR DESCRIPTION
## Summary
- extend app tests to cover model selection and estimation
- add comprehensive token estimator tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864c8fda0ec833294f71486e132254f