### PR TITLE
Improve XML translation handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -153,7 +153,7 @@ def _run_translation_job(
             tree = load_story_xml(story_path)
             contents = extract_content_elements(tree)
             all_contents.append((story_path, tree, contents))
-            for _, text in contents:
+            for _, text, _ in contents:
                 all_texts.append(text)
 
         def _progress(pct: int) -> None:
@@ -307,7 +307,7 @@ def estimate():
             for story_path in find_story_files(extract_dir):
                 tree = load_story_xml(story_path)
                 contents = extract_content_elements(tree)
-                for _, txt in contents:
+                for _, txt, _ in contents:
                     texts.append(txt)
 
     texts = list(dict.fromkeys(texts))

--- a/tests/test_text_extractor.py
+++ b/tests/test_text_extractor.py
@@ -3,7 +3,7 @@ from lxml import etree
 import os
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from translator.text_extractor import extract_content_elements
+from translator.text_extractor import extract_content_elements, update_content_elements
 
 
 def test_extract_content_elements_ignores_empty():
@@ -17,5 +17,21 @@ def test_extract_content_elements_ignores_empty():
     """
     tree = etree.fromstring(xml)
     results = extract_content_elements(tree)
-    texts = [text for _, text in results]
+    texts = [text for _, text, _ in results]
     assert texts == ["First", "Second"]
+
+
+def test_extract_and_update_with_markup():
+    xml = """
+    <Root>
+        <Content>Hello<b>bold</b>!</Content>
+    </Root>
+    """
+    tree = etree.fromstring(xml)
+    results = extract_content_elements(tree)
+    assert results[0][1] == "Hello[[TAG1]]bold[[TAG2]]!"
+    assert results[0][2] == ["<b>", "</b>"]
+
+    update_content_elements(results, ["Ahoj[[TAG1]]tučně[[TAG2]]!"])
+    content = etree.tostring(tree, encoding="unicode")
+    assert "Ahoj<b>tučně</b>!" in content

--- a/translator/openai_client.py
+++ b/translator/openai_client.py
@@ -119,23 +119,17 @@ def _split_batches(texts: list[str], max_tokens: int, model: str) -> list[list[s
 
 def _parse_numbered(translated: str) -> list[str]:
     """Parse numbered translation output into a list of texts."""
-    lines = [line.strip() for line in translated.splitlines() if line.strip()]
+    import re
+
+    lines = [line for line in translated.splitlines() if line.strip()]
     results: list[str] = []
+    pattern = re.compile(r"^\s*\d+\W*\s*(.*)$")
     for line in lines:
-        if line[0].isdigit():
-            # remove leading number + punctuation
-            parts = line.split(".", 1)
-            if len(parts) == 2 and parts[0].strip().isdigit():
-                results.append(parts[1].strip())
-            else:
-                parts = line.split(" ", 1)
-                if len(parts) == 2 and parts[0].strip().isdigit():
-                    results.append(parts[1].strip())
-                else:
-                    results.append(line)
+        match = pattern.match(line)
+        if match:
+            results.append(match.group(1))
         elif results:
-            # continuation of previous line
-            results[-1] += " " + line
+            results[-1] += " " + line.strip()
     return results
 
 

--- a/translator/text_extractor.py
+++ b/translator/text_extractor.py
@@ -3,6 +3,40 @@
 from __future__ import annotations
 
 from lxml import etree
+import re
+
+TAG_PATTERN = re.compile(r"<[^>]+>")
+
+def _tags_to_placeholders(text: str) -> tuple[str, list[str]]:
+    """Replace XML tags in ``text`` with numbered placeholders."""
+
+    tags: list[str] = []
+
+    def repl(match: re.Match[str]) -> str:
+        tags.append(match.group(0))
+        return f"[[TAG{len(tags)}]]"
+
+    return TAG_PATTERN.sub(repl, text), tags
+
+
+def _placeholders_to_tags(text: str, tags: list[str]) -> str:
+    """Reinsert ``tags`` into ``text`` replacing placeholders."""
+
+    for i, tag in enumerate(tags, 1):
+        text = text.replace(f"[[TAG{i}]]", tag)
+    return text
+
+
+def _set_inner_xml(el: etree._Element, xml: str) -> None:
+    """Replace contents of ``el`` with parsed ``xml``."""
+
+    for child in list(el):
+        el.remove(child)
+    el.text = None
+    wrapper = etree.fromstring(f"<wrapper>{xml}</wrapper>")
+    el.text = wrapper.text
+    for child in wrapper:
+        el.append(child)
 
 def load_story_xml(story_path):
     """
@@ -24,16 +58,21 @@ def extract_content_elements(tree):
     content_elements = tree.xpath('//*[local-name()="Content"]')
     result = []
     for el in content_elements:
-        if el.text and el.text.strip():  # ignoruj prázdné
-            result.append((el, el.text))
+        inner = (el.text or '') + ''.join(
+            etree.tostring(child, encoding='unicode') for child in el
+        )
+        if inner.strip():
+            text, tags = _tags_to_placeholders(inner)
+            result.append((el, text, tags))
     return result
 
 def update_content_elements(content_list, translations):
     """
     Přepíše obsah elementů přeloženým textem
     """
-    for (el, _), new_text in zip(content_list, translations):
-        el.text = new_text
+    for (el, _, tags), new_text in zip(content_list, translations):
+        xml = _placeholders_to_tags(new_text, tags)
+        _set_inner_xml(el, xml)
 
 def save_story_xml(tree, output_path):
     """


### PR DESCRIPTION
## Summary
- preserve inline XML/IDML tags by replacing them with numbered placeholders
- restore tags after translation and write back the full markup
- allow `_parse_numbered` to keep placeholder tokens
- test markup extraction and update

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864d49b4e648332827f9be6b1924749