### PR TITLE
Switch default model to gpt-4o

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A simple Flask application for translating IDML (InDesign Markup Language) files
    ```bash
    pip install -r requirements.txt
    ```
-2. Set the environment variables `OPENAI_API_KEY`, and optionally `FLASK_SECRET_KEY`, `APP_PASSWORD` and `OPENAI_MODEL` (default `gpt-4`).
+2. Set the environment variables `OPENAI_API_KEY`, and optionally `FLASK_SECRET_KEY`, `APP_PASSWORD` and `OPENAI_MODEL` (default `gpt-4o`).
 3. Run the app:
    ```bash
    python app.py

--- a/app.py
+++ b/app.py
@@ -35,7 +35,7 @@ import tempfile
 app = Flask(__name__)
 app.secret_key = os.environ.get("FLASK_SECRET_KEY", "devsecret")
 PASSWORD = os.environ.get("APP_PASSWORD", "banana")
-DEFAULT_MODEL = os.environ.get("OPENAI_MODEL", "gpt-4")
+DEFAULT_MODEL = os.environ.get("OPENAI_MODEL", "gpt-4o")
 app.config['UPLOAD_FOLDER'] = 'uploads'
 app.config['RESULT_FOLDER'] = 'results'
 

--- a/translator/openai_client.py
+++ b/translator/openai_client.py
@@ -32,7 +32,7 @@ class ChatTranslator:
         source_lang: str,
         target_lang: str,
         system_prompt: str | None = None,
-        model: str = "gpt-4",
+        model: str = "gpt-4o",
     ) -> None:
         from_lang = LANGUAGE_MAP.get(source_lang, source_lang)
         to_lang = LANGUAGE_MAP.get(target_lang, target_lang)
@@ -76,7 +76,7 @@ def translate_text(
     source_lang: str,
     target_lang: str,
     system_prompt: str | None = None,
-    model: str = "gpt-4",
+    model: str = "gpt-4o",
 ) -> str:
     """Translate ``text`` from ``source_lang`` to ``target_lang`` using ChatGPT."""
     from_lang = LANGUAGE_MAP.get(source_lang, source_lang)
@@ -142,7 +142,7 @@ def batch_translate(
     *,
     max_tokens: int = 800,
     delay: float | None = 1.0,
-    model: str = "gpt-4",
+    model: str = "gpt-4o",
 ) -> dict[str, list[str]]:
     """Translate ``texts`` into ``target_langs`` using OpenAI in batches."""
 
@@ -205,7 +205,7 @@ async def async_batch_translate(
     *,
     max_tokens: int = 800,
     delay: float | None = None,
-    model: str = "gpt-4",
+    model: str = "gpt-4o",
 ) -> dict[str, list[str]]:
     """Asynchronously translate ``texts`` into ``target_langs`` using OpenAI."""
 


### PR DESCRIPTION
## Summary
- switch the default OpenAI model to gpt-4o
- update documentation and helper classes

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864d986bc088332a936ac525dcf2626