### PR TITLE
Improve translation token estimates

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,7 +26,12 @@ from translator.text_extractor import (
     save_story_xml
 )
 from translator.openai_client import batch_translate, DEFAULT_PROMPT
-from translator.token_estimator import count_tokens, estimate_cost, MODEL_RATES
+from translator.token_estimator import (
+    count_tokens,
+    estimate_cost,
+    MODEL_RATES,
+    estimate_total_tokens,
+)
 import shutil
 import time
 import threading
@@ -311,7 +316,7 @@ def estimate():
                     texts.append(txt)
 
     texts = list(dict.fromkeys(texts))
-    tokens = count_tokens(texts, model)
+    tokens = estimate_total_tokens(texts, model)
     cost = estimate_cost(tokens, model, len(selected_languages))
     return jsonify({'tokens': tokens, 'cost': round(cost, 4)})
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -102,7 +102,7 @@ def test_index_passes_selected_model(monkeypatch, tmp_path):
 
 
 def test_estimate_route(monkeypatch, tmp_path):
-    monkeypatch.setattr(app_module, 'count_tokens', lambda texts, model: 1000)
+    monkeypatch.setattr(app_module, 'estimate_total_tokens', lambda texts, model: 1000)
     idml_path = tmp_path / 'e.idml'
     _create_idml(idml_path)
     client = app.test_client()
@@ -121,11 +121,11 @@ def test_estimate_route(monkeypatch, tmp_path):
 def test_estimate_deduplicates_texts(monkeypatch, tmp_path):
     captured = {}
 
-    def fake_count(texts, model):
+    def fake_est(texts, model):
         captured['texts'] = texts
         return len(texts)
 
-    monkeypatch.setattr(app_module, 'count_tokens', fake_count)
+    monkeypatch.setattr(app_module, 'estimate_total_tokens', fake_est)
 
     idml_path = tmp_path / 'dup.idml'
     _create_idml_duplicate(idml_path)

--- a/tests/test_token_estimator.py
+++ b/tests/test_token_estimator.py
@@ -1,6 +1,12 @@
 import tiktoken
 import pytest
-from translator.token_estimator import count_tokens, estimate_cost, MODEL_RATES
+from translator.token_estimator import (
+    count_tokens,
+    estimate_cost,
+    MODEL_RATES,
+    estimate_total_tokens,
+    DEFAULT_SYSTEM_PROMPT,
+)
 
 
 class DummyEncoder:
@@ -32,4 +38,29 @@ def test_count_tokens_returns_zero_on_error(monkeypatch):
 def test_estimate_cost_default_rate():
     cost = estimate_cost(1000, "unknown", 3)
     assert cost == (1000 / 1000) * 0.03 * 3
+
+
+def test_estimate_total_tokens_adds_overhead(monkeypatch):
+    captured = []
+
+    def fake_count(texts, model):
+        captured.append(list(texts))
+        return len(texts)
+
+    monkeypatch.setattr(tiktoken, "get_encoding", lambda name: DummyEncoder())
+    monkeypatch.setattr(
+        'translator.token_estimator.count_tokens',
+        fake_count,
+    )
+
+    tokens = estimate_total_tokens(["a", "b"], "gpt-4")
+    # count_tokens should be called four times: unique texts, system prompt,
+    # instruction text and markers
+    assert captured[0] == ['a', 'b']
+    assert captured[1] == [DEFAULT_SYSTEM_PROMPT]
+    assert captured[2] == [
+        'Translate the following segments labelled [[SEG1]]..[[SEGN]]. Provide the translations on separate lines using the same labels:'
+    ]
+    assert captured[3] == ['[[SEG1]]', '[[SEG2]]']
+    assert tokens == sum(len(c) for c in captured)
 


### PR DESCRIPTION
## Summary
- expose `estimate_total_tokens` helper to approximate prompt overhead
- cap conversation history in `ChatTranslator` to avoid quadratic token growth
- use the new token estimation in `/estimate`
- update and expand tests for the new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864e00a656883329aaf63a39048568f