### PR TITLE
Improve /credit endpoint feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The web UI includes a drop-down to select the chat model for each translation jo
 
 The app can also show the remaining credit for your OpenAI API key via the
 ``/credit`` endpoint which the front-end displays under the model selector.
+If the API key is missing or the credit endpoint cannot be reached the page
+will show ``Zbývající kredit není dostupný`` instead.
 
 When IDML files and target languages are selected the page now displays an
 estimate of the number of tokens that will be sent to the OpenAI API along with

--- a/app.py
+++ b/app.py
@@ -334,7 +334,12 @@ def estimate():
 @app.route('/credit')
 def credit():
     """Return remaining credit for the configured API key."""
+    api_key = os.environ.get('OPENAI_API_KEY')
+    if not api_key:
+        return jsonify({'credit': None, 'error': 'unavailable'})
     value = get_remaining_credit()
+    if value is None:
+        return jsonify({'credit': None, 'error': 'unavailable'})
     return jsonify({'credit': value})
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -150,10 +150,10 @@
         if (json.credit !== null && json.credit !== undefined) {
           info.textContent = `Zbývající kredit: $${json.credit.toFixed(4)}`;
         } else {
-          info.textContent = '';
+          info.textContent = 'Zbývající kredit není dostupný.';
         }
       } catch (e) {
-        info.textContent = '';
+        info.textContent = 'Zbývající kredit není dostupný.';
       }
     }
   </script>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -150,3 +150,21 @@ def test_credit_route(monkeypatch):
     resp = client.get('/credit')
     assert resp.status_code == 200
     assert resp.get_json() == {'credit': 42.0}
+
+
+def test_credit_route_unavailable(monkeypatch):
+    monkeypatch.setattr(app_module, 'get_remaining_credit', lambda: None)
+    os.environ['OPENAI_API_KEY'] = 'test'
+    client = app.test_client()
+    resp = client.get('/credit')
+    assert resp.status_code == 200
+    assert resp.get_json() == {'credit': None, 'error': 'unavailable'}
+
+
+def test_credit_route_missing_key(monkeypatch):
+    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
+    monkeypatch.setattr(app_module, 'get_remaining_credit', lambda: 42.0)
+    client = app.test_client()
+    resp = client.get('/credit')
+    assert resp.status_code == 200
+    assert resp.get_json() == {'credit': None, 'error': 'unavailable'}


### PR DESCRIPTION
## Summary
- return an error flag when remaining credit cannot be retrieved
- display a message in the UI when credit is unavailable
- document behaviour in README
- test the new cases for `/credit`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864fa065e08833286c9055d8cb54659