### PR TITLE
Show tokens used after translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ A simple Flask application for translating IDML (InDesign Markup Language) files
 
 The web UI includes a drop-down to select the chat model for each translation job.
 
-The app can also show the remaining credit for your OpenAI API key via the
-``/credit`` endpoint which the front-end displays under the model selector.
+The app tracks how many OpenAI tokens were consumed by the most recent
+translation job. This is exposed via the ``/tokens`` endpoint and shown under
+the model selector on the main page.
 
 When IDML files and target languages are selected the page now displays an
 estimate of the number of tokens that will be sent to the OpenAI API along with

--- a/templates/index.html
+++ b/templates/index.html
@@ -45,7 +45,7 @@
     </select>
 
     <div id="estimate-info" style="margin-top:10px;font-weight:bold;"></div>
-    <div id="credit-info" style="margin-top:10px;font-weight:bold;"></div>
+    <div id="token-info" style="margin-top:10px;font-weight:bold;"></div>
 
     <label for="prompt">AI Prompt:</label>
     <textarea name="prompt" rows="4">{{ prompt_text }}</textarea>
@@ -136,19 +136,19 @@
       document.querySelectorAll('input[name="languages"]').forEach(el => el.addEventListener('change', estimateTokens));
       if (fileInput) fileInput.addEventListener('change', estimateTokens);
       if (modelSelect) modelSelect.addEventListener('change', estimateTokens);
-      loadCredit();
+      loadTokens();
     });
   </script>
   <script>
-    async function loadCredit() {
-      const info = document.getElementById('credit-info');
+    async function loadTokens() {
+      const info = document.getElementById('token-info');
       if (!info) return;
       try {
-        const res = await fetch('/credit');
+        const res = await fetch('/tokens');
         if (!res.ok) throw new Error();
         const json = await res.json();
-        if (json.credit !== null && json.credit !== undefined) {
-          info.textContent = `Zbývající kredit: $${json.credit.toFixed(4)}`;
+        if (json.tokens !== null && json.tokens !== undefined && json.tokens > 0) {
+          info.textContent = `Poslední překlad spotřeboval ${json.tokens} tokenů.`;
         } else {
           info.textContent = '';
         }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -144,9 +144,9 @@ def test_estimate_deduplicates_texts(monkeypatch, tmp_path):
     assert result == {'tokens': len(captured['texts']), 'cost': expected}
 
 
-def test_credit_route(monkeypatch):
-    monkeypatch.setattr(app_module, 'get_remaining_credit', lambda: 42.0)
+def test_tokens_route_returns_last_value(monkeypatch):
+    app_module.LAST_TOKENS_USED = 123
     client = app.test_client()
-    resp = client.get('/credit')
+    resp = client.get('/tokens')
     assert resp.status_code == 200
-    assert resp.get_json() == {'credit': 42.0}
+    assert resp.get_json() == {'tokens': 123}

--- a/translator/openai_client.py
+++ b/translator/openai_client.py
@@ -183,6 +183,7 @@ def batch_translate(
     source_lang: str,
     system_prompt: str | None = None,
     progress_callback: callable | None = None,
+    tokens_callback: callable | None = None,
     *,
     max_tokens: int = 800,
     delay: float | None = 1.0,
@@ -219,6 +220,8 @@ def batch_translate(
                     messages=translator.messages,
                     temperature=0.3,
                 )
+                if tokens_callback and getattr(response, "usage", None):
+                    tokens_callback(getattr(response.usage, "total_tokens", 0))
                 reply = response.choices[0].message.content.strip("\n")
                 translator.messages.append({"role": "assistant", "content": reply})
                 if len(translator.messages) > ChatTranslator.HISTORY_LIMIT + 1:
@@ -248,6 +251,7 @@ async def async_batch_translate(
     source_lang: str,
     system_prompt: str | None = None,
     progress_callback: callable | None = None,
+    tokens_callback: callable | None = None,
     *,
     max_tokens: int = 800,
     delay: float | None = None,
@@ -289,6 +293,8 @@ async def async_batch_translate(
                 messages=translator.messages,
                 temperature=0.3,
             )
+            if tokens_callback and getattr(response, "usage", None):
+                tokens_callback(getattr(response.usage, "total_tokens", 0))
             reply = response.choices[0].message.content.strip("\n")
             translator.messages.append({"role": "assistant", "content": reply})
             if len(translator.messages) > ChatTranslator.HISTORY_LIMIT + 1:


### PR DESCRIPTION
## Summary
- track token usage in `batch_translate` and `async_batch_translate`
- store token count for each job and expose it via `/tokens`
- show last job's token usage in the web UI
- document the `/tokens` endpoint
- add regression test for `/tokens`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864fa065e08833286c9055d8cb54659