### PR TITLE
Escape ampersands before reinserting tags

### DIFF
--- a/tests/test_text_extractor.py
+++ b/tests/test_text_extractor.py
@@ -51,3 +51,17 @@ def test_extract_and_update_with_br():
     update_content_elements(results, ["Ahoj[[TAG1]]Svete"])
     content = etree.tostring(tree, encoding="unicode")
     assert "Ahoj<br/>Svete" in content
+
+
+def test_update_content_elements_escapes_ampersand():
+    xml = """
+    <Root>
+        <Content>Hello<b>bold</b></Content>
+    </Root>
+    """
+    tree = etree.fromstring(xml)
+    results = extract_content_elements(tree)
+    update_content_elements(results, ["Hi & [[TAG1]]x[[TAG2]]"])
+    content = etree.tostring(tree, encoding="unicode")
+    etree.fromstring(content)
+    assert "Hi &amp; <b>x</b>" in content

--- a/translator/text_extractor.py
+++ b/translator/text_extractor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from lxml import etree
+import html
 import re
 
 TAG_PATTERN = re.compile(r"<[^>]+>")
@@ -21,7 +22,7 @@ def _tags_to_placeholders(text: str) -> tuple[str, list[str]]:
 
 def _placeholders_to_tags(text: str, tags: list[str]) -> str:
     """Reinsert ``tags`` into ``text`` replacing placeholders."""
-
+    text = html.escape(text, quote=False)
     for i, tag in enumerate(tags, 1):
         text = text.replace(f"[[TAG{i}]]", tag)
     return text


### PR DESCRIPTION
## Summary
- escape text in `_placeholders_to_tags` with `html.escape`
- add regression test for ampersands in `update_content_elements`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68665e55c8748332ba8b6c58b5b7c651