### PR TITLE
Add flake8 linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Lint
+        run: flake8
+      - name: Test
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -38,10 +38,12 @@ adjust ``MAX_BATCH_TOKENS`` (default ``800``) to control how many tokens are sen
 in each API call.  Higher values reduce the number of requests but must remain
 within the selected model's context limit.
 
-## Tests
+## Tests and style
 
-Install test dependencies and run the suite with:
+Install test dependencies and run style checks with:
 ```bash
 pip install -r requirements.txt
+flake8
 pytest
 ```
+The included GitHub Actions workflow also runs these commands on every push.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ blinker==1.9.0
 certifi==2025.6.15
 click==8.2.1
 distro==1.9.0
+flake8==7.3.0
 Flask==3.1.1
 h11==0.16.0
 httpcore==1.0.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[flake8]
+ignore = E501
+exclude = .git,__pycache__,venv
+


### PR DESCRIPTION
## Summary
- add flake8 dependency
- configure flake8
- document style checks and CI in README
- run flake8 and pytest in GitHub Actions

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68665f60dad48332adaf52560b3a2822