### PR TITLE
Fix flake8 E226 issues

### DIFF
--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -1,7 +1,8 @@
 import sys
 import os
 import asyncio
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from translator import openai_client  # noqa: E402
 
@@ -12,9 +13,11 @@ def test_batch_translate_batches_and_caches(monkeypatch):
     models = []
 
     def fake_create(*args, **kwargs):
-        prompt = kwargs['messages'][-1]['content']
-        lines = [line for line in prompt.splitlines() if line.strip().startswith('[[SEG')]
-        pieces = [line.split(']]', 1)[1].strip() for line in lines]
+        prompt = kwargs["messages"][-1]["content"]
+        lines = [
+            line for line in prompt.splitlines() if line.strip().startswith("[[SEG")
+        ]
+        pieces = [line.split("]]", 1)[1].strip() for line in lines]
 
         class M:
             pass
@@ -23,22 +26,22 @@ def test_batch_translate_batches_and_caches(monkeypatch):
         resp.choices = [M()]
         resp.choices[0].message = M()
         resp.choices[0].message.content = "\n".join(
-            f"[[SEG{i+1}]] {p}_t" for i, p in enumerate(pieces)
+            f"[[SEG{i + 1}]] {p}_t" for i, p in enumerate(pieces)
         )
         calls.append(prompt)
-        models.append(kwargs.get('model'))
+        models.append(kwargs.get("model"))
         return resp
 
-    monkeypatch.setattr(openai_client.client.chat.completions, 'create', fake_create)
+    monkeypatch.setattr(openai_client.client.chat.completions, "create", fake_create)
 
-    texts = ['Hello', 'Hello', 'World']
-    result = openai_client.batch_translate(texts, ['cs'], 'en', model='gpt-3.5-turbo')
-    assert result['cs'] == ['Hello_t', 'Hello_t', 'World_t']
+    texts = ["Hello", "Hello", "World"]
+    result = openai_client.batch_translate(texts, ["cs"], "en", model="gpt-3.5-turbo")
+    assert result["cs"] == ["Hello_t", "Hello_t", "World_t"]
     # both unique segments should be sent in one request
     assert len(calls) == 1
-    assert '[[SEG1]] Hello' in calls[0]
-    assert '[[SEG2]] World' in calls[0]
-    assert models == ['gpt-3.5-turbo']
+    assert "[[SEG1]] Hello" in calls[0]
+    assert "[[SEG2]] World" in calls[0]
+    assert models == ["gpt-3.5-turbo"]
 
 
 def test_async_batch_translate(monkeypatch):
@@ -47,9 +50,11 @@ def test_async_batch_translate(monkeypatch):
     models = []
 
     async def fake_create(*args, **kwargs):
-        prompt = kwargs['messages'][-1]['content']
-        lines = [line for line in prompt.splitlines() if line.strip().startswith('[[SEG')]
-        pieces = [line.split(']]', 1)[1].strip() for line in lines]
+        prompt = kwargs["messages"][-1]["content"]
+        lines = [
+            line for line in prompt.splitlines() if line.strip().startswith("[[SEG")
+        ]
+        pieces = [line.split("]]", 1)[1].strip() for line in lines]
 
         class M:
             pass
@@ -58,34 +63,42 @@ def test_async_batch_translate(monkeypatch):
         resp.choices = [M()]
         resp.choices[0].message = M()
         resp.choices[0].message.content = "\n".join(
-            f"[[SEG{i+1}]] {p}_t" for i, p in enumerate(pieces)
+            f"[[SEG{i + 1}]] {p}_t" for i, p in enumerate(pieces)
         )
         calls.append(prompt)
-        models.append(kwargs.get('model'))
+        models.append(kwargs.get("model"))
         return resp
 
-    monkeypatch.setattr(openai_client.async_client.chat.completions, 'create', fake_create)
+    monkeypatch.setattr(
+        openai_client.async_client.chat.completions, "create", fake_create
+    )
 
-    texts = ['Hi', 'Bye']
-    result = asyncio.run(openai_client.async_batch_translate(texts, ['cs', 'de'], 'en', delay=None, model='gpt-3.5-turbo'))
-    assert result['cs'] == ['Hi_t', 'Bye_t']
-    assert result['de'] == ['Hi_t', 'Bye_t']
+    texts = ["Hi", "Bye"]
+    result = asyncio.run(
+        openai_client.async_batch_translate(
+            texts, ["cs", "de"], "en", delay=None, model="gpt-3.5-turbo"
+        )
+    )
+    assert result["cs"] == ["Hi_t", "Bye_t"]
+    assert result["de"] == ["Hi_t", "Bye_t"]
     assert len(calls) == 2
-    assert models == ['gpt-3.5-turbo', 'gpt-3.5-turbo']
+    assert models == ["gpt-3.5-turbo", "gpt-3.5-turbo"]
 
 
 def test_split_batches_respects_tokens(monkeypatch):
-    monkeypatch.setattr(openai_client, 'count_tokens', lambda texts, model: len(texts[0]))
+    monkeypatch.setattr(
+        openai_client, "count_tokens", lambda texts, model: len(texts[0])
+    )
 
-    texts = ['aaaaa', 'bb', 'ccc']
-    batches = openai_client._split_batches(texts, 5, 'gpt-3.5-turbo')
-    assert batches == [['aaaaa'], ['bb', 'ccc']]
+    texts = ["aaaaa", "bb", "ccc"]
+    batches = openai_client._split_batches(texts, 5, "gpt-3.5-turbo")
+    assert batches == [["aaaaa"], ["bb", "ccc"]]
 
 
 def test_parse_segments_preserves_spaces():
     translated = "[[SEG1]]  Hello \n[[SEG2]]  World  "
     result = openai_client._parse_segments(translated)
-    assert result == [' Hello ', ' World  ']
+    assert result == [" Hello ", " World  "]
 
 
 def test_get_remaining_credit(monkeypatch):

--- a/translator/openai_client.py
+++ b/translator/openai_client.py
@@ -75,7 +75,9 @@ class ChatTranslator:
             from_lang=from_lang,
             to_lang=to_lang,
         )
-        self.messages: list[ChatCompletionMessageParam] = [{"role": "system", "content": prompt}]
+        self.messages: list[ChatCompletionMessageParam] = [
+            {"role": "system", "content": prompt}
+        ]
         self.cache: dict[str, str] = {}
         self.model = model
 
@@ -95,7 +97,9 @@ class ChatTranslator:
             translation = response.choices[0].message.content.strip("\n")
             self.messages.append({"role": "assistant", "content": translation})
             if len(self.messages) > self.HISTORY_LIMIT + 1:
-                self.messages = [self.messages[0]] + self.messages[-self.HISTORY_LIMIT:]
+                self.messages = [
+                    self.messages[0]
+                ] + self.messages[-self.HISTORY_LIMIT:]
             self.cache[text] = translation
             return translation
         except Exception as e:  # pragma: no cover - network errors
@@ -195,7 +199,8 @@ def batch_translate(
 
     results = {lang: [] for lang in target_langs}
     translators = {
-        lang: ChatTranslator(source_lang, lang, system_prompt, model) for lang in target_langs
+        lang: ChatTranslator(source_lang, lang, system_prompt, model)
+        for lang in target_langs
     }
 
     counts: dict[str, int] = {}
@@ -210,7 +215,7 @@ def batch_translate(
     for lang, translator in translators.items():
         to_translate = [t for t in unique_texts if t not in translator.cache]
         for batch in _split_batches(to_translate, max_tokens, model):
-            marked = "\n".join(f"[[SEG{i+1}]] {t}" for i, t in enumerate(batch))
+            marked = "\n".join(f"[[SEG{i + 1}]] {t}" for i, t in enumerate(batch))
             prompt = (
                 f"Translate the following segments labelled [[SEG1]]..[[SEG{len(batch)}]]. "
                 "Provide the translations on separate lines using the same labels:\n" + marked
@@ -227,7 +232,9 @@ def batch_translate(
                 reply = response.choices[0].message.content.strip("\n")
                 translator.messages.append({"role": "assistant", "content": reply})
                 if len(translator.messages) > ChatTranslator.HISTORY_LIMIT + 1:
-                    translator.messages = [translator.messages[0]] + translator.messages[-ChatTranslator.HISTORY_LIMIT:]
+                    translator.messages = [
+                        translator.messages[0]
+                    ] + translator.messages[-ChatTranslator.HISTORY_LIMIT:]
             except Exception as e:  # pragma: no cover - network errors
                 print(f"❌ Chyba při překladu: {e}")
                 reply = "\n".join(batch)
@@ -268,7 +275,8 @@ async def async_batch_translate(
 
     results = {lang: [] for lang in target_langs}
     translators = {
-        lang: ChatTranslator(source_lang, lang, system_prompt, model) for lang in target_langs
+        lang: ChatTranslator(source_lang, lang, system_prompt, model)
+        for lang in target_langs
     }
 
     counts: dict[str, int] = {}
@@ -281,9 +289,11 @@ async def async_batch_translate(
     unique_texts = list(dict.fromkeys(texts))
     tasks = []
 
-    async def translate_batch(lang: str, translator: ChatTranslator, batch: list[str]) -> None:
+    async def translate_batch(
+        lang: str, translator: ChatTranslator, batch: list[str]
+    ) -> None:
         nonlocal done
-        marked = "\n".join(f"[[SEG{i+1}]] {t}" for i, t in enumerate(batch))
+        marked = "\n".join(f"[[SEG{i + 1}]] {t}" for i, t in enumerate(batch))
         prompt = (
             f"Translate the following segments labelled [[SEG1]]..[[SEG{len(batch)}]]. "
             "Provide the translations on separate lines using the same labels:\n" + marked
@@ -300,7 +310,9 @@ async def async_batch_translate(
             reply = response.choices[0].message.content.strip("\n")
             translator.messages.append({"role": "assistant", "content": reply})
             if len(translator.messages) > ChatTranslator.HISTORY_LIMIT + 1:
-                translator.messages = [translator.messages[0]] + translator.messages[-ChatTranslator.HISTORY_LIMIT:]
+                translator.messages = [
+                    translator.messages[0]
+                ] + translator.messages[-ChatTranslator.HISTORY_LIMIT:]
         except Exception as e:  # pragma: no cover - network errors
             print(f"❌ Chyba při překladu: {e}")
             reply = "\n".join(batch)

--- a/translator/token_estimator.py
+++ b/translator/token_estimator.py
@@ -65,7 +65,7 @@ def estimate_total_tokens(
         ],
         model,
     )
-    markers = [f"[[SEG{i+1}]]" for i in range(len(unique))]
+    markers = [f"[[SEG{i + 1}]]" for i in range(len(unique))]
     tokens += count_tokens(markers, model)
 
     # Rough protocol overhead for a single chat completion


### PR DESCRIPTION
## Summary
- resolve flake8 E226 whitespace warnings in tests and translator modules
- keep formatter compatible with flake8

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68667af3ba3c8332945620896dd031e6