### PR TITLE
Add editor textarea

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -206,3 +206,7 @@
       width: 0;
       transition: width 0.3s ease;
     }
+
+textarea#edit-box {
+    overflow: hidden;
+}

--- a/templates/editor.html
+++ b/templates/editor.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="cs">
+<head>
+  <meta charset="UTF-8">
+  <title>Editor</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+  <h1>Editor</h1>
+  <textarea id="edit-box" rows="4"></textarea>
+
+  <script>
+    function autoResize() {
+      this.style.height = 'auto';
+      this.style.height = this.scrollHeight + 'px';
+    }
+    const box = document.getElementById('edit-box');
+    if (box) {
+      box.addEventListener('input', autoResize);
+      window.addEventListener('DOMContentLoaded', function () {
+        autoResize.call(box);
+      });
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new page `editor.html` with an editable textarea
- auto-resize the textarea when typing
- hide scrollbars on the edit box in CSS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870bf9dd1108332b6da298a70132a87